### PR TITLE
Issue5 explicit path handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ Gemfile.lock
 *.gem
 .byebug_history
 *.swp
+.bundle
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Gemfile.lock
 *.gem
 .byebug_history
+*.swp

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ myResolver = Uc3Ssm::ConfigResolver.new()
 
 ### Public Instance Methods
 
-`**myResolver.parameter_for_key(key)**` - perform a simple lookup for a single
-                                          ssm parameter.  
+#### `parameter_for_key(key)`
+
+perform a simple lookup for a single ssm parameter.  
 
 When `key` is prefixed be a forward slash (e.g. `/cleverman` or
 `/price/tea/china`), it is considered to be a fully qualified parameter name
@@ -96,29 +97,89 @@ client_secret = ssm.parameter_for_key('client_secret') || ''
 ```
 
 
-TODO:  this is not acurate
+#### `parameters_for_path(**options)`
 
-**myResolver.parameters_for_path(**options)** - perform a recursive lookup for all
-                                               parameters prefixed by `options['path']`.
+perform a lookup for all parameters prefixed by `options['path']`.
 
-As with `myResolver.parameter_for_key(key)`, when `path` is not fully
+As with `myResolver.parameter_for_key(key)`, when `options[path]` is not fully
 qualified, `ssm_root_path` is prepended to `path` to form a fully qualified
-parameter path.
+parameter path.  If `options['path'] is not specified, then the search is done
+with `ssm_root_path.
+
+All other keys in `options` are passed to `Aws::SSM::Client.get_parameters_by_path`.
+See https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/SSM/Client.html#get_parameters_by_path-instance_method
 
 Example:
 
 ```ruby
 myResolver = Uc3Ssm::ConfigResolver.new(ssm_root_path: "/my/base/path")
 myResolver.parameter_for_key(path: 'args')
-# returns values for all parameter names starting with "/my/base/path/args"
+# returns values for all parameter names directly under "/my/base/path/args"
+
+myResolver.parameter_for_key(path: 'args', resursive: true)
+# returns values for all parameter names recursively starting with "/my/base/path/args"
 ```
 
-TODO: need docs for
 
-- resolve_file_values
-- resolve_hash_values
+#### `resolve_file_values(file:, resolve_key: nil, return_key: nil)`
+
+Performs SSM (or ENV) parameter resolution of within a yaml config file formatted for
+uc3-ssm lookups.  For a complete usage example see below at
+[Resolve System Configuration with the AWS SSM Parameter Store](#resolve-system-configuration-with-the-aws-ssm-parameter-store)
+
+options:
+
+- `file`        - config file to process
+- `resolve_key` - partially process config file using this as a root key - use this to prevent unnecessary lookups
+- `return_key`  - return values for a specific hash key - use this to filter the return object
+
+`resolve_file_values` returns a hash of the loaded yaml file with substitions
+from values resolved from SSM or ENV based on the following markup syntax:
+
+```
+> cat myvars.yaml
+mySsmVar: {!SSM: ssmkey !DEFAULT: some_default_value} 
+myEnvVar: {!ENV: ENV_VAR !DEFAULT: other_default_value} 
+myNoNetVar: {!SSM: nonetkey}
+```
+
+`ssmkey` is treated as the search key as in method `parameter_for_key`.  The
+`!SSM` markup text surrounded by brackets gets replaced either by a value found
+in SSM or by `default_value`.
+
+In like manner a lookup of `ENV_VAR` in the ENV object replaces `{!ENV}` markup text.
+
+If the `Uc3Ssm::ConfigResolver` instance was initiated with `dev_value`, and no
+`!DEFAULT` was specified for a lookup, then if a lookup fails to resolve, the
+value of `def_value` is used for the default.
+
+ 
+**Example:**
+
+Assuming SSM pamameter `/my/root/path/sskey => 'blee'` and `ENV['ENV_VAR'].nil?` is true:
+
+```ruby
+require uc3-ssm
+myResolver = Uc3Ssm::ConfigResolver.new(
+  ssm_root_path: "/my/root/path"
+  region: "us-west-2",
+  def_value: "NOT_FOUND",
+)
+
+myvars = myResolver.resolve_file_values('myvars.yaml')
+puts myvars
+{:mySsmVar=>"blee", :myEnvVar=>"some_other_value", :myNoNetVar=>"NOT_FOUND"}
+```
 
 
+
+#### `def resolve_hash_values(hash:, resolve_key: nil, return_key: nil)`
+
+- hash - config hash to process
+- resolve_key - partially process config hash using this as a root key - use this to prevent unnecessary lookups
+- return_key - return values for a specific hash key - use this to filter the return object
+
+This works essentially the same as `resolve_file_values`.  The difference being the input is a ruby hash instead of a yaml file
 
 
 

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ myResolver = Uc3Ssm::ConfigResolver.new(
   region: "us-west-2",
   def_value: "NOT_FOUND",
 )
-
 myvars = myResolver.resolve_file_values('myvars.yaml')
+
 puts myvars
 {:mySsmVar=>"blee", :myEnvVar=>"some_other_value", :myNoNetVar=>"NOT_FOUND"}
 ```
@@ -175,11 +175,16 @@ puts myvars
 
 #### `def resolve_hash_values(hash:, resolve_key: nil, return_key: nil)`
 
-- hash - config hash to process
-- resolve_key - partially process config hash using this as a root key - use this to prevent unnecessary lookups
-- return_key - return values for a specific hash key - use this to filter the return object
+Performs SSM (or ENV) parameter resolution of within a ruby hash object formatted for
+uc3-ssm lookups.
 
-This works essentially the same as `resolve_file_values`.  The difference being the input is a ruby hash instead of a yaml file
+This works essentially the same as `resolve_file_values`.  The difference being
+the input is a ruby hash instead of a yaml file.
+
+- `hash`        - config hash to process
+- `resolve_key` - partially process config hash using this as a root key - use this to prevent unnecessary lookups
+- `return_key`  - return values for a specific hash key - use this to filter the return object
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A library for looking up configuration parameters in AWS SSM ParameterStore.
 Intended for use by CDL UC3 services.  We rely on EC2 instance profiles to provide AWS credentials and SSM access policy.
 
 
-# Basic Usage - the Uc3Ssm::ConfigResolver object
+## Basic Usage - the Uc3Ssm::ConfigResolver object
 
 ### Parameters
 
@@ -33,8 +33,8 @@ Intended for use by CDL UC3 services.  We rely on EC2 instance profiles to provi
 Default instance has no `ssm_root_path`.  All lookup keys must be fully qualified.
 
 ```ruby
-  require uc3-ssm
-  myDefaultResolver = Uc3Ssm::ConfigResolver.new()
+require uc3-ssm
+myDefaultResolver = Uc3Ssm::ConfigResolver.new()
 ```
 
 
@@ -42,24 +42,25 @@ Explicit parameter declaration.  All unqualified lookup keys will have the
 `ssm_root_path` prepended when passed as parameter names to SSM ParameterStore.
 
 ```ruby
-  myResolver = Uc3Ssm::ConfigResolver.new(
-    ssm_root_path: "/my/root/path"
-    region: "us-west-2",
+myResolver = Uc3Ssm::ConfigResolver.new(
+  ssm_root_path: "/my/root/path"
+  region: "us-west-2",
 )
 ```
 
 Implicit parameter declaration using environment vars.
 
 ```ruby
-  export SSM_ROOT_PATH=/my/other/root/path
-  export AWS_REGION=us-west-2
-  myResolver = Uc3Ssm::ConfigResolver.new()
+ENV['SSM_ROOT_PATH'] = '/my/other/root/path'
+ENV['AWS_REGION'] = 'us-west-2'
+myResolver = Uc3Ssm::ConfigResolver.new()
 ```
 
 
 ### Public Instance Methods
 
-**myResolver.parameter_for_key(key)** - perform a simple lookup for a single ssm parameter.  
+`**myResolver.parameter_for_key(key)**` - perform a simple lookup for a single
+                                          ssm parameter.  
 
 When `key` is prefixed be a forward slash (e.g. `/cleverman` or
 `/price/tea/china`), it is considered to be a fully qualified parameter name
@@ -72,7 +73,7 @@ slash prefix), an exception is thrown.
 
 Example:
 
-```
+```ruby
 myResolver = Uc3Ssm::ConfigResolver.new(ssm_root_path: "/my/root/path")
 myResolver.parameter_for_key('/cheese/blue')
 # returns value for parameter name '/cheese/blue'
@@ -85,20 +86,39 @@ myDefaultResolver.parameter_for_key('blee')
 # throws ConfigResolverError exception
 ```
 
-
-**myResolver.parameters_for_path(path)** - perform a recursive lookup for all parameters prefixed by `path`.
-
-As with `myResolver.parameter_for_key(key)`, when `path` is not fully qualified, `ssm_root_path` is prepended to `path` to form a fully qualified parameter path.
-
-
-
-
 Example of directly retrieving API credentials from SSM
+
 ```ruby
-  ssm = Uc3Ssm::ConfigResolver.new
-  client_id = ssm.parameter_for_key('client_id') || ''
-  client_secret = ssm.parameter_for_key('client_secret') || ''
+ENV['SSM_ROOT_PATH'] = '/my/path/'
+ssm = Uc3Ssm::ConfigResolver.new
+client_id = ssm.parameter_for_key('client_id') || ''
+client_secret = ssm.parameter_for_key('client_secret') || ''
 ```
+
+
+TODO:  this is not acurate
+
+**myResolver.parameters_for_path(**options)** - perform a recursive lookup for all
+                                               parameters prefixed by `options['path']`.
+
+As with `myResolver.parameter_for_key(key)`, when `path` is not fully
+qualified, `ssm_root_path` is prepended to `path` to form a fully qualified
+parameter path.
+
+Example:
+
+```ruby
+myResolver = Uc3Ssm::ConfigResolver.new(ssm_root_path: "/my/base/path")
+myResolver.parameter_for_key(path: 'args')
+# returns values for all parameter names starting with "/my/base/path/args"
+```
+
+TODO: need docs for
+
+- resolve_file_values
+- resolve_hash_values
+
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,107 @@
+Rubygem uc3-ssm
+===============
+
+A library for looking up configuration parameters in AWS SSM ParameterStore.
+
+Intended for use by CDL UC3 services.  We rely on EC2 instance profiles to provide AWS credentials and SSM access policy.
+
+
+# Basic Usage - the Uc3Ssm::ConfigResolver object
+
+### Parameters
+
+- `ssm_root_path`: prefix to apply to all parameter name lookups.  This must be
+  a fully qualified parameter path, i.e. it must start with a forward slash
+  ('/').  Defaults to value of environment var `SSM_ROOT_PATH` if defined.
+
+- `region`: AWS region in which to perform the SSM lookup.  Defaults to value
+  of environment var `AWS_REGION` if defined, or failing that, to `us-west-2`. 
+
+- `def_value`: (optional) a global fallback value to return when a lookup key
+  does not match any parameter names in SSM ParameterStore and no local default
+  is defined.  This can help prevent exceptions from being thrown in your
+  applications.  Defaults to empty string ('').
+
+- `ssm_skip_resolution`: boolean flag.   When set, no SSM ParameterStore
+  lookups will occur.  Key lookups fall back to local environment lookups or to
+  defined default values.  Defaults to value of environment var
+  `SSM_SKIP_RESOLUTION` if defined.
+
+
+### Instantiation 
+
+Default instance has no `ssm_root_path`.  All lookup keys must be fully qualified.
+
+```ruby
+  require uc3-ssm
+  myDefaultResolver = Uc3Ssm::ConfigResolver.new()
+```
+
+
+Explicit parameter declaration.  All unqualified lookup keys will have the
+`ssm_root_path` prepended when passed as parameter names to SSM ParameterStore.
+
+```ruby
+  myResolver = Uc3Ssm::ConfigResolver.new(
+    ssm_root_path: "/my/root/path"
+    region: "us-west-2",
+)
+```
+
+Implicit parameter declaration using environment vars.
+
+```ruby
+  export SSM_ROOT_PATH=/my/other/root/path
+  export AWS_REGION=us-west-2
+  myResolver = Uc3Ssm::ConfigResolver.new()
+```
+
+
+### Public Instance Methods
+
+**myResolver.parameter_for_key(key)** - perform a simple lookup for a single ssm parameter.  
+
+When `key` is prefixed be a forward slash (e.g. `/cleverman` or
+`/price/tea/china`), it is considered to be a fully qualified parameter name
+and is passed 'as is' to SSM.  If not so prefixed, then `ssm_root_path` is
+prepended to `key` to form a fully qualified parameter name.
+
+NOTE: if `ssm_root_path` is not defined, and `key` is unqualified (no forward
+slash prefix), an exception is thrown.
+
+
+Example:
+
+```
+myResolver = Uc3Ssm::ConfigResolver.new(ssm_root_path: "/my/root/path")
+myResolver.parameter_for_key('/cheese/blue')
+# returns value for parameter name '/cheese/blue'
+
+myResolver.parameter_for_key('blee')
+# returns value for parameter name '/my/root/path/blee'
+
+myDefaultResolver = Uc3Ssm::ConfigResolver.new()
+myDefaultResolver.parameter_for_key('blee')
+# throws ConfigResolverError exception
+```
+
+
+**myResolver.parameters_for_path(path)** - perform a recursive lookup for all parameters prefixed by `path`.
+
+As with `myResolver.parameter_for_key(key)`, when `path` is not fully qualified, `ssm_root_path` is prepended to `path` to form a fully qualified parameter path.
+
+
+
+
+Example of directly retrieving API credentials from SSM
+```ruby
+  ssm = Uc3Ssm::ConfigResolver.new
+  client_id = ssm.parameter_for_key('client_id') || ''
+  client_secret = ssm.parameter_for_key('client_secret') || ''
+```
+
+
+
 # Resolve System Configuration with the AWS SSM Parameter Store
 
 ## Original System Configuration File
@@ -211,13 +315,6 @@ def config.database_configuration
   # The entire config must be returned, but only the Rails.env will be processed
   load_uc3_config({ name: 'database.yml', resolve_key: Rails.env })
 end
-```
-
-Example of directly retrieving API credentials from SSM
-```ruby
-  ssm = Uc3Ssm::ConfigResolver.new
-  client_id = ssm.parameter_for_key('client_id') || ''
-  client_secret = ssm.parameter_for_key('client_secret') || ''
 ```
 
 ### Installation - Ruby Lambda

--- a/lib/uc3-ssm.rb
+++ b/lib/uc3-ssm.rb
@@ -53,8 +53,8 @@ module Uc3Ssm
       resolve_hash_values(hash: config, resolve_key: resolve_key, return_key: return_key)
     end
 
-    # hash - config hash file to process
-    # resolve_key - partially process config file using this as a root key - use this to prevent unnecessary lookups
+    # hash - config hash to process
+    # resolve_key - partially process config hash using this as a root key - use this to prevent unnecessary lookups
     # return_key - return values for a specific hash key - use this to filter the return object
     def resolve_hash_values(hash:, resolve_key: nil, return_key: nil)
       if resolve_key && hash.key?(resolve_key)
@@ -67,7 +67,7 @@ module Uc3Ssm
     end
 
     # Retrieve all key+values for a path (using the ssm_root_path if none is specified)
-    # See https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/SSM/Client.html for
+    # See https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/SSM/Client.html#get_parameters_by_path-instance_method
     # details on available `options`
     def parameters_for_path(**options)
       return [] if @ssm_skip_resolution

--- a/lib/uc3-ssm.rb
+++ b/lib/uc3-ssm.rb
@@ -72,7 +72,7 @@ module Uc3Ssm
     def parameters_for_path(**options)
       return [] if @ssm_skip_resolution
 
-      options[:path] = @ssm_root_path if options[:path].nil?
+      options[:path] = options[:path].nil? ? @ssm_root_path : sanitize_parameter_key(options[:path])
       resp = @client.get_parameters_by_path(options)
       !resp.nil? && resp.parameters.any? ? resp.parameters : []
     rescue Aws::Errors::MissingCredentialsError

--- a/lib/uc3-ssm.rb
+++ b/lib/uc3-ssm.rb
@@ -88,6 +88,8 @@ module Uc3Ssm
 
     # Ensure root_path starts and ends with '/'
     def sanitize_root_path(root_path)
+      return root_path if root_path.empty?
+
       raise ConfigResolverError, 'ssm_root_path must start with backslash' unless root_path.start_with?('/')
 
       root_path.end_with?('/') ? root_path : root_path + '/'

--- a/lib/uc3-ssm/version.rb
+++ b/lib/uc3-ssm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Uc3Ssm
-  VERSION = '0.1.11'
+  VERSION = '0.2.0'
 end

--- a/spec/test/initialize_resolver_object_spec.rb
+++ b/spec/test/initialize_resolver_object_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'spec_helper.rb'
+require 'aws-sdk-ssm'
+
+# rubocop:disable Metrics/BlockLength
+RSpec.describe 'initialize_resolver_object_tests', type: :feature do
+  context 'new instance creation' do
+    describe 'ConfigResolver.new with no options' do
+      myResolver = Uc3Ssm::ConfigResolver.new
+      it 'sets @region to default' do
+        expect(myResolver.instance_variable_get(:@region)).to eq('us-west-2')
+      end
+      it 'sets @ssm_root_path to default' do
+        expect(myResolver.instance_variable_get(:@ssm_root_path)).to eq('')
+      end
+      it 'sets @def_value to default' do
+        expect(myResolver.instance_variable_get(:@def_value)).to eq('')
+      end
+      it 'sets @ssm_skip_resolution to false' do
+        expect(myResolver.instance_variable_get(:@ssm_skip_resolution)).to be false
+      end
+      it 'sets @client to AWS SSM Client object' do
+        expect(myResolver.instance_variable_get(:@client)).to be_instance_of(Aws::SSM::Client)
+      end
+    end
+
+    describe 'ConfigResolver.new with options' do
+      myResolver = Uc3Ssm::ConfigResolver.new(
+        region: 'us-east-1',
+        ssm_root_path: '/root/path/',
+        def_value: 'NOT_APPLICABLE'
+      )
+      it 'sets @region' do
+        expect(myResolver.instance_variable_get(:@region)).to eq('us-east-1')
+      end
+      it 'sets @ssm_root_path' do
+        expect(myResolver.instance_variable_get(:@ssm_root_path)).to eq('/root/path/')
+      end
+      it 'sets @def_value' do
+        expect(myResolver.instance_variable_get(:@def_value)).to eq('NOT_APPLICABLE')
+      end
+    end
+
+    describe 'ConfigResolver.new with ENV vars' do
+      ENV['AWS_REGION'] = 'eu-east-3'
+      ENV['SSM_ROOT_PATH'] = '/root/path/no/trailing/slash'
+      ENV['SSM_SKIP_RESOLUTION'] = 'Y'
+      myResolver = Uc3Ssm::ConfigResolver.new
+      it 'sets @region' do
+        expect(myResolver.instance_variable_get(:@region)).to eq('eu-east-3')
+      end
+      it '@ssm_root_path has trailing slash' do
+        expect(myResolver.instance_variable_get(:@ssm_root_path)).to eq('/root/path/no/trailing/slash/')
+      end
+      it 'sets @ssm_skip_resolution to true' do
+        expect(myResolver.instance_variable_get(:@ssm_skip_resolution)).to be true
+      end
+      it 'sets @client to AWS SSM Client object' do
+        expect(myResolver.instance_variable_get(:@client)).to be nil
+      end
+    end
+
+    describe 'ConfigResolver.new with bad input' do
+      ENV['SSM_ROOT_PATH'] = 'no/starting/slash/'
+      it '@ssm_root_path raises exception' do
+        expect {badResolver = Uc3Ssm::ConfigResolver.new}.to raise_exception(Uc3Ssm::ConfigResolverError)
+      end
+    end
+  end
+end

--- a/spec/test/initialize_resolver_object_spec.rb
+++ b/spec/test/initialize_resolver_object_spec.rb
@@ -5,6 +5,7 @@ require 'aws-sdk-ssm'
 
 # rubocop:disable Metrics/BlockLength
 RSpec.describe 'initialize_resolver_object_tests', type: :feature do
+
   context 'new instance creation' do
     describe 'ConfigResolver.new with no options' do
       myResolver = Uc3Ssm::ConfigResolver.new


### PR DESCRIPTION
I have applied the logic around explicit path handling as noted in #5.  This includes two new private methods:

- `sanitize_root_path`
- `sanitize_parameter_key`

I also added a suite of rspec tests for `ConfigResolver` object instantiation, plus a few more method tests around explicit path handling.  I had to fix several existing test to conform to the new logic.

I added a **Basic Usage** section to the readme with details on object instantiation and public methods.