### PR TITLE
Update to get `parameters_for_path` to return ALL SSM parameters for the given path

### DIFF
--- a/lib/uc3-ssm/version.rb
+++ b/lib/uc3-ssm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Uc3Ssm
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end


### PR DESCRIPTION
AWS SSM (or at least the aws-sdk-ssm client from their gem) supports a `max_results` argument and appears to have had an unpublished default of 10 results. Surprise! 
https://github.com/aws/aws-sdk-ruby/blob/4e33a1d42eebc2c97f8b3ea1baa81ddad9836c6b/gems/aws-sdk-ssm/lib/aws-sdk-ssm/client.rb#L6126

The DMPTool has more than 10 parameters stored. This patch will continue to issue `get-parameters-by-path` requests until the aws-sdk-ssm client stops returning a `next_token`.


