### PR TITLE
Enable decryption of SSM parameters

### DIFF
--- a/lib/uc3-ssm.rb
+++ b/lib/uc3-ssm.rb
@@ -228,7 +228,6 @@ module Uc3Ssm
     # Attempt to retrieve the value from AWS SSM
     def retrieve_ssm_value(key)
       return key if @ssm_skip_resolution
-      puts 'get with decrypt '
       @client.get_parameter(name: key, with_decryption: true)[:parameter][:value]
     rescue Aws::SSM::Errors::ParameterNotFound
       @logger.debug "ParameterNotFound for key '#{key}' in retrieve_ssm_value"

--- a/lib/uc3-ssm.rb
+++ b/lib/uc3-ssm.rb
@@ -229,7 +229,7 @@ module Uc3Ssm
     def retrieve_ssm_value(key)
       return key if @ssm_skip_resolution
 
-      @client.get_parameter(name: key)[:parameter][:value]
+      @client.get_parameter(name: key, with_decryption: true)[:parameter][:value]
     rescue Aws::SSM::Errors::ParameterNotFound
       @logger.debug "ParameterNotFound for key '#{key}' in retrieve_ssm_value"
       nil

--- a/lib/uc3-ssm.rb
+++ b/lib/uc3-ssm.rb
@@ -228,7 +228,7 @@ module Uc3Ssm
     # Attempt to retrieve the value from AWS SSM
     def retrieve_ssm_value(key)
       return key if @ssm_skip_resolution
-
+      puts 'get with decrypt '
       @client.get_parameter(name: key, with_decryption: true)[:parameter][:value]
     rescue Aws::SSM::Errors::ParameterNotFound
       @logger.debug "ParameterNotFound for key '#{key}' in retrieve_ssm_value"

--- a/lib/uc3-ssm/version.rb
+++ b/lib/uc3-ssm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Uc3Ssm
-  VERSION = '0.3.7'
+  VERSION = '0.3.8'
 end

--- a/lib/uc3-ssm/version.rb
+++ b/lib/uc3-ssm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Uc3Ssm
-  VERSION = '0.3.9'
+  VERSION = '0.3.10'
 end

--- a/lib/uc3-ssm/version.rb
+++ b/lib/uc3-ssm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Uc3Ssm
-  VERSION = '0.3.8'
+  VERSION = '0.3.9'
 end

--- a/spec/test/resolver_spec.rb
+++ b/spec/test/resolver_spec.rb
@@ -46,19 +46,19 @@ RSpec.describe 'basic_resolver_tests', type: :feature do
         "ARN": "arn:aws:ssm:us-west-2:1111111111:parameter#{name}"
       }
     }
-    allow_any_instance_of(Aws::SSM::Client).to receive(:get_parameter).with({ name: name })
+    allow_any_instance_of(Aws::SSM::Client).to receive(:get_parameter).with({ name: name, with_decryption: true })
                                                                       .and_return(param_json)
   end
   # rubocop:enable Metrics/MethodLength
 
   def mock_ssm_failure(name, err)
-    allow_any_instance_of(Aws::SSM::Client).to receive(:get_parameter).with({ name: name })
+    allow_any_instance_of(Aws::SSM::Client).to receive(:get_parameter).with({ name: name, with_decryption: true })
                                                                       .and_raise(err)
   end
 
   def mock_ssm_not_found(name)
     allow_any_instance_of(Aws::SSM::Client).to receive(:get_parameter)
-        .with({ name: name })
+        .with({ name: name, with_decryption: true })
         .and_raise(Aws::SSM::Errors::ParameterNotFound.new({}, name))
   end
 


### PR DESCRIPTION
Prepare uc3-ssm gem for the use of SecureString parameters.

- @briri , would you like any changes to the get_parameters_by_path call or would you expect the client to always pass `with_decryption: true`